### PR TITLE
Hotfix: Fix auth URL

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-const REPLIT_URL = "whenflagclicked.org"; // Please change this URL to your replit URL before starting!
+const REPLIT_URL = "www.whenflagclicked.org"; // Please change this URL to your replit URL before starting!
 const express = require("express");
 const fs = require("fs");
 const readDir = require("./libs/readDir");


### PR DESCRIPTION
Resolves #49

**Changes**

Fix the authentication url, switches it from whenflagclicked.org to www.whenflagclicked.org 

**Reason for changes**

auth needs to be fixed asap
