### PR TITLE
Add embed support

### DIFF
--- a/pages/new/index.html
+++ b/pages/new/index.html
@@ -56,8 +56,25 @@
             function addEmbeds(html) {
               // this is a kind of hacky way to do it since the markdown is sanitized
               return html
-              .replace(/\$<a href="(.*?)">(.*?)<\/a>/g, (match, url, title) => `<iframe width="560" height="315" src="https://www.youtube.com/embed/${/(\/youtube\/|\?v=)(.*?)($|\/|&|#)/.exec(url)[2].replace(/"/g, '\\"')}" title="${title.replace(/"/g, '\\"')}" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>`)
-              .replace(/<a href="(\d+)">(project|turbowarp)<\/a>/g, (match, id, website) => `<iframe src="https://${website === 'turbowarp' ? 'turbowarp.org' :'scratch.mit.edu/projects'}/${id}/embed" allowtransparency="true" width="485" height="402" frameborder="0" scrolling="no" allowfullscreen></iframe>`);
+                .replace(
+                  /\$<a href="(.*?)">(.*?)<\/a>/g,
+                  (match, url, title) =>
+                    `<iframe width="560" height="315" src="https://www.youtube.com/embed/${/(\/youtube\/|\?v=)(.*?)($|\/|&|#)/
+                      .exec(url)[2]
+                      .replace(/"/g, '\\"')}" title="${title.replace(
+                      /"/g,
+                      '\\"'
+                    )}" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>`
+                )
+                .replace(
+                  /<a href="(\d+)">(project|turbowarp)<\/a>/g,
+                  (match, id, website) =>
+                    `<iframe src="https://${
+                      website === "turbowarp"
+                        ? "turbowarp.org"
+                        : "scratch.mit.edu/projects"
+                    }/${id}/embed" allowtransparency="true" width="485" height="402" frameborder="0" scrolling="no" allowfullscreen></iframe>`
+                );
             }
 
             return addEmbeds(marked(this.input, { sanitize: true }));

--- a/pages/new/index.html
+++ b/pages/new/index.html
@@ -56,7 +56,7 @@
             function addEmbeds(html) {
               // this is a kind of hacky way to do it since the markdown is sanitized
               return html
-              .replace(/\$<a href="(.*?)">(.*?)<\/a>/g, (match, url, title) => `<iframe width="560" height="315" src="https://www.youtube.com/embed/${/(\/youtube\/|\?v=)(.*?)($|\/|&|#)/.exec(url)?.[2]}" title="${title.replace(/"/g, '\\"')}" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>`)
+              .replace(/\$<a href="(.*?)">(.*?)<\/a>/g, (match, url, title) => `<iframe width="560" height="315" src="https://www.youtube.com/embed/${/(\/youtube\/|\?v=)(.*?)($|\/|&|#)/.exec(url)[2].replace(/"/g, '\\"')}" title="${title.replace(/"/g, '\\"')}" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>`)
               .replace(/<a href="(\d+)">(project|turbowarp)<\/a>/g, (match, id, website) => `<iframe src="https://${website === 'turbowarp' ? 'turbowarp.org' :'scratch.mit.edu/projects'}/${id}/embed" allowtransparency="true" width="485" height="402" frameborder="0" scrolling="no" allowfullscreen></iframe>`);
             }
 

--- a/pages/new/index.html
+++ b/pages/new/index.html
@@ -53,7 +53,14 @@
             };
             requestAnimationFrame(renderCodeblocks);
 
-            return marked(this.input, { sanitize: true });
+            function addEmbeds(html) {
+              // this is a kind of hacky way to do it since the markdown is sanitized
+              return html
+              .replace(/\$<a href="(.*?)">(.*?)<\/a>/g, (match, url, title) => `<iframe width="560" height="315" src="https://www.youtube.com/embed/${/(\/youtube\/|\?v=)(.*?)($|\/|&|#)/.exec(url)?.[2]}" title="${title.replace(/"/g, '\\"')}" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>`)
+              .replace(/<a href="(\d+)">(project|turbowarp)<\/a>/g, (match, id, website) => `<iframe src="https://${website === 'turbowarp' ? 'turbowarp.org' :'scratch.mit.edu/projects'}/${id}/embed" allowtransparency="true" width="485" height="402" frameborder="0" scrolling="no" allowfullscreen></iframe>`);
+            }
+
+            return addEmbeds(marked(this.input, { sanitize: true }));
           },
         },
         methods: {


### PR DESCRIPTION
**Resolves**

Resolves #69 

**Changes**

Anything of the form `$[embed title](youtube url)` gets replaced with an embedded youtube video. Both youtube and scratch.mit.edu/discuss/youtube links work.
Projects can be embedded (with scratch or turbowarp) with `[project](project id)` or `[turbowarp](project id)`.

Note: I did not add syntax to embed user/studio info, because I feel like that's something for a different PR.