### PR TITLE
Revert "Bump node-fetch from 2.6.1 to 3.0.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "express": "^4.17.1",
     "js-cookie": "^3.0.0",
     "monk": "^7.3.4",
-    "node-fetch": "^3.0.0",
+    "node-fetch": "^2.6.1",
     "nuxt": "^2.15.7"
   },
   "keywords": []


### PR DESCRIPTION
Reverts FlagClicked/FlagClicked#100

It's curently causing server problems